### PR TITLE
Bumped SDK version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metriport"
-version = "8.0.0-beta"
+version = "8.0.1-beta"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/metriport/core/client_wrapper.py
+++ b/src/metriport/core/client_wrapper.py
@@ -14,7 +14,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "metriport",
-            "X-Fern-SDK-Version": "8.0.0-beta",
+            "X-Fern-SDK-Version": "8.0.1-beta",
         }
         headers["X-API-Key"] = self.api_key
         return headers


### PR DESCRIPTION
Bumped version from 8.0.0-beta to 8.0.1-beta because of errors on manual PyPI Deployment:

 HTTP Error 400: File already exists.
 HTTP Error 400: This filename has already been used, use a different version.